### PR TITLE
Fix undefined DOM references in popup script

### DIFF
--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -1,3 +1,8 @@
+const qrimg = document.getElementById('qrimg');
+const qrtext_url = document.getElementById('qrtext_url');
+const qrtext_title = document.getElementById('qrtext_title');
+const copy_btn = document.getElementById('copy-btn');
+
 function refreshQR(text) {
     const value = qrtext_url.value || text || '';
     qrcode.stringToBytes = qrcode.stringToBytesFuncs['UTF-8'];


### PR DESCRIPTION
## Summary
- query popup DOM elements by id to avoid undefined references

## Testing
- `node --check extension/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6858f8ef61e0832a995dadd4105b5dd8