### PR TITLE
Increase QR code size

### DIFF
--- a/extension/css/main.css
+++ b/extension/css/main.css
@@ -6,3 +6,7 @@
     width: 100%;
     height: auto;
 }
+
+body {
+    width: 600px;
+}

--- a/extension/js/main.js
+++ b/extension/js/main.js
@@ -9,7 +9,7 @@ function refreshQR(text) {
     const qr = qrcode(0, 'L');
     qr.addData(value);
     qr.make();
-    qrimg.innerHTML = qr.createSvgTag(4);
+    qrimg.innerHTML = qr.createSvgTag(12);
 }
 
 qrtext_url.addEventListener('input', () => refreshQR());


### PR DESCRIPTION
## Summary
- enlarge QR code to triple size by increasing cell size
- keep the SVG responsive to fit available width
- widen popup width so enlarged QR code fits

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858facbab8c832aba247bf225164a02